### PR TITLE
Adjust mobile review popup position

### DIFF
--- a/client/src/components/BookingModal.css
+++ b/client/src/components/BookingModal.css
@@ -244,13 +244,13 @@
 @media (max-width: 768px) {
   .modal-overlay {
     padding: 1rem;
-    align-items: flex-start;
+    align-items: center;
   }
   
   .booking-modal {
-    max-height: 95vh;
+    max-height: 90vh;
     width: 95%;
-    margin-top: 70px;
+    margin-top: 0;
   }
   
   .modal-header,
@@ -279,14 +279,14 @@
 @media (max-width: 480px) {
   .modal-overlay {
     padding: 0.5rem;
-    align-items: flex-start;
+    align-items: center;
   }
   
   .booking-modal {
-    max-height: 98vh;
+    max-height: 85vh;
     width: 98%;
     border-radius: 12px;
-    margin-top: 60px;
+    margin-top: 0;
   }
   
   .modal-header {


### PR DESCRIPTION
Adjust review modal positioning on mobile to prevent overlap with the navigation bar and center it.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dd2b5ae-5c4e-4ace-97e0-20ec8e1a0d69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dd2b5ae-5c4e-4ace-97e0-20ec8e1a0d69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>