### PR TITLE
Fix readme rendering and add server sleep notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ T-Finder is a full-stack web application designed to connect users with skilled 
 - **Review and Rating System**: Users can leave feedback and ratings for technicians.
 - **Responsive Dashboard**: Separate dashboards for users and technicians to manage bookings, profiles, and reviews.
 - **Mobile-First Design**: A fully responsive UI that works beautifully on all devices.
+- **Server Information Popup**: Beautiful animated popup that informs users about the backend hosting on Render.com and provides guidance for server sleep issues.
 
 ## 🛠️ Tech Stack
 
@@ -53,10 +54,10 @@ This diagram illustrates the high-level architecture of the T-Finder application
 
 ```mermaid
 graph TD
-    A[User's Browser] -- HTTPS --> B{Frontend (React + Vite)};
-    B -- API Calls (Axios) --> C{Backend (Node.js + Express)};
-    C -- Mongoose ODM --> D[(MongoDB Database)];
-    C -- Manages Auth --> A;
+    A[User's Browser] -->|HTTPS| B{Frontend (React + Vite)};
+    B -->|API Calls (Axios)| C{Backend (Node.js + Express)};
+    C -->|Mongoose ODM| D[(MongoDB Database)];
+    C -->|Manages Auth| A;
 ```
 
 ## 🌊 User Flow

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import ServerInfoPopup from './ServerInfoPopup';
 
 const Layout = ({ children }) => {
   return (
     <>
+      <ServerInfoPopup />
       <Navbar />
       <main className="main-content">
         {children}

--- a/client/src/components/ServerInfoBanner.jsx
+++ b/client/src/components/ServerInfoBanner.jsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { IoClose, IoInformationCircle, IoServer } from 'react-icons/io5';
+
+const ServerInfoBanner = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  useEffect(() => {
+    // Check if user has dismissed the banner before
+    const dismissed = localStorage.getItem('serverBannerDismissed');
+    if (!dismissed) {
+      // Show banner after 1 second
+      const timer = setTimeout(() => {
+        setIsVisible(true);
+      }, 1000);
+
+      return () => clearTimeout(timer);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    setIsDismissed(true);
+    localStorage.setItem('serverBannerDismissed', 'true');
+  };
+
+  const handleClose = () => {
+    setIsVisible(false);
+  };
+
+  if (isDismissed) return null;
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          initial={{ opacity: 0, y: -100 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -100 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          className="fixed top-0 left-0 right-0 z-50 bg-gradient-to-r from-blue-500 to-purple-600 text-white shadow-lg"
+        >
+          <div className="max-w-7xl mx-auto px-4 py-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3 flex-1">
+                <IoServer className="text-white text-xl flex-shrink-0" />
+                <div className="flex items-center gap-4 text-sm">
+                  <span className="font-medium">
+                    <IoInformationCircle className="inline mr-1" />
+                    Backend hosted on Render.com
+                  </span>
+                  <span className="hidden sm:inline">•</span>
+                  <span className="hidden sm:inline">
+                    Server may sleep after inactivity
+                  </span>
+                  <span className="hidden md:inline">•</span>
+                  <span className="hidden md:inline">
+                    Wait 40 seconds if experiencing issues
+                  </span>
+                </div>
+              </div>
+              
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleDismiss}
+                  className="text-white/80 hover:text-white text-xs px-2 py-1 rounded transition-colors"
+                >
+                  Don't show again
+                </button>
+                <button
+                  onClick={handleClose}
+                  className="text-white/80 hover:text-white transition-colors p-1"
+                >
+                  <IoClose className="text-lg" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default ServerInfoBanner;

--- a/client/src/components/ServerInfoPopup.jsx
+++ b/client/src/components/ServerInfoPopup.jsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { IoClose, IoInformationCircle, IoServer } from 'react-icons/io5';
+
+const ServerInfoPopup = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  useEffect(() => {
+    // Check if user has dismissed the popup before
+    const dismissed = localStorage.getItem('serverInfoDismissed');
+    if (!dismissed) {
+      // Show popup after 1 second
+      const timer = setTimeout(() => {
+        setIsVisible(true);
+      }, 1000);
+
+      return () => clearTimeout(timer);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    setIsDismissed(true);
+    localStorage.setItem('serverInfoDismissed', 'true');
+  };
+
+  const handleClose = () => {
+    setIsVisible(false);
+  };
+
+  if (isDismissed) return null;
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          initial={{ opacity: 0, y: -50, scale: 0.9 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -50, scale: 0.9 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          className="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 max-w-md w-full mx-4"
+        >
+          <div className="bg-white/95 backdrop-blur-md rounded-2xl shadow-2xl border border-gray-200/50 overflow-hidden">
+            {/* Header */}
+            <div className="bg-gradient-to-r from-blue-500 to-purple-600 p-4 relative">
+              <div className="flex items-center gap-3">
+                <div className="flex-shrink-0">
+                  <IoServer className="text-white text-2xl" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-white font-semibold text-lg">Server Information</h3>
+                  <p className="text-blue-100 text-sm">Important notice about our backend</p>
+                </div>
+                <button
+                  onClick={handleClose}
+                  className="flex-shrink-0 text-white/80 hover:text-white transition-colors"
+                >
+                  <IoClose className="text-xl" />
+                </button>
+              </div>
+            </div>
+
+            {/* Content */}
+            <div className="p-4">
+              <div className="flex items-start gap-3 mb-4">
+                <IoInformationCircle className="text-blue-500 text-xl flex-shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-gray-700 text-sm leading-relaxed">
+                    Our backend is hosted on <span className="font-semibold text-blue-600">Render.com</span>. 
+                    After periods of inactivity, the server may go to sleep to conserve resources.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4">
+                <div className="flex items-start gap-2">
+                  <div className="w-2 h-2 bg-amber-500 rounded-full mt-2 flex-shrink-0"></div>
+                  <div>
+                    <p className="text-amber-800 text-sm font-medium mb-1">
+                      If you're experiencing issues:
+                    </p>
+                    <ul className="text-amber-700 text-sm space-y-1">
+                      <li>• No data loading</li>
+                      <li>• Backend not responding</li>
+                      <li>• API errors</li>
+                    </ul>
+                    <p className="text-amber-800 text-sm font-medium mt-2">
+                      Simply wait <span className="font-bold">40 seconds</span> and the server will wake up automatically!
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Action Buttons */}
+              <div className="flex gap-3">
+                <button
+                  onClick={handleDismiss}
+                  className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium py-2 px-4 rounded-lg transition-colors text-sm"
+                >
+                  Don't show again
+                </button>
+                <button
+                  onClick={handleClose}
+                  className="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-lg transition-colors text-sm"
+                >
+                  Got it
+                </button>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default ServerInfoPopup;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix Mermaid diagram syntax in README and add a server information popup to inform users about backend sleep on Render.com.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The Mermaid diagram in the README was unrenderable due to a syntax error. To enhance user experience and provide transparency, a new server information popup has been implemented. This popup informs users that the backend is hosted on Render.com, where servers may sleep after inactivity, and advises them to wait approximately 40 seconds if they encounter initial loading delays.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e8a2634-a397-4286-b6a0-84c87df96ce8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3e8a2634-a397-4286-b6a0-84c87df96ce8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>